### PR TITLE
Polish reading/player UX, unify sliders, and streamline navigation drawer

### DIFF
--- a/lib/backend/android_audio_display_mode.dart
+++ b/lib/backend/android_audio_display_mode.dart
@@ -16,6 +16,7 @@ class AndroidAudioDisplayMode {
   static double? _lastAppliedFrameRate;
   static Timer? _idleTimer;
   static DateTime? _lastUserActivityAt;
+  static int _lowFpsSuppressionCount = 0;
 
   static bool get _isSupported => !kIsWeb && Platform.isAndroid;
 
@@ -34,6 +35,7 @@ class AndroidAudioDisplayMode {
     }
 
     await _applyPreferredFrameRate(_systemFrameRate);
+    if (_lowFpsSuppressionCount > 0) return;
     _scheduleIdleFrameRate();
   }
 
@@ -42,7 +44,26 @@ class AndroidAudioDisplayMode {
 
     _lastUserActivityAt = DateTime.now();
     unawaited(_applyPreferredFrameRate(_systemFrameRate));
+    if (_lowFpsSuppressionCount > 0) return;
     _idleTimer ??= Timer(idleDelay, () => _handleIdleTimer(idleDelay));
+  }
+
+  static Future<void> setLowFpsSuppressed(bool suppressed) async {
+    if (!_isSupported) return;
+    if (suppressed) {
+      _lowFpsSuppressionCount++;
+      _idleTimer?.cancel();
+      _idleTimer = null;
+      await _applyPreferredFrameRate(_systemFrameRate);
+      return;
+    }
+
+    if (_lowFpsSuppressionCount > 0) {
+      _lowFpsSuppressionCount--;
+    }
+    if (_lowFpsSuppressionCount == 0 && _audioPlaybackActive) {
+      _scheduleIdleFrameRate();
+    }
   }
 
   static void _scheduleIdleFrameRate() {
@@ -55,6 +76,10 @@ class AndroidAudioDisplayMode {
 
   static void _handleIdleTimer(Duration idleDelay) {
     if (!_audioPlaybackActive) {
+      _idleTimer = null;
+      return;
+    }
+    if (_lowFpsSuppressionCount > 0) {
       _idleTimer = null;
       return;
     }

--- a/lib/home/home.dart
+++ b/lib/home/home.dart
@@ -4,28 +4,13 @@ import 'package:equran/home/downloads.dart';
 import 'package:equran/home/main_page.dart';
 import 'package:equran/home/player.dart';
 import 'package:equran/home/settings.dart';
-import 'package:equran/utils/app_radii.dart';
 import 'package:equran/utils/responsive_nav.dart';
 import 'package:flutter/material.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:share_plus/share_plus.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-const String _appDownloadUrl =
-    'https://f-droid.org/en/packages/com.app.equran/';
-const String _issueReportUrl = 'https://github.com/ya27hw/equran_app/issues';
-const String _contactEmail = 'equran@elbaesy.com';
 const EdgeInsets _drawerTilePadding = EdgeInsets.symmetric(horizontal: 12);
-const double _drawerTileLeadingGap = 16;
-const double _drawerTileIconLabelGap = 12;
 
 class Destinations {
-  const Destinations(
-    this.label,
-    this.icon,
-    this.selectedIcon,
-    this.destination,
-  );
+  const Destinations(this.label, this.icon, this.selectedIcon, this.destination);
 
   final String label;
   final Widget icon;
@@ -42,54 +27,40 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _selectedIndex = 0;
-  final List<Destinations> _pageDestinations = <Destinations>[
-    const Destinations(
-      "eQuran",
-      Icon(Icons.book_outlined),
-      Icon(Icons.book),
-      MainPage(),
-    ),
-    const Destinations(
-      "Player",
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  final List<Destinations> _pageDestinations = const <Destinations>[
+    Destinations('Home', Icon(Icons.home_outlined), Icon(Icons.home_rounded), MainPage()),
+    Destinations(
+      'Player',
       Icon(Icons.library_music_outlined),
       Icon(Icons.library_music),
       PlayerPage(),
     ),
-    const Destinations(
-      "Downloads",
+    Destinations(
+      'Downloads',
       Icon(Icons.download_done_outlined),
       Icon(Icons.download_done_rounded),
       DownloadsPage(),
     ),
-    const Destinations(
-      "Settings",
-      Icon(Icons.settings_outlined),
-      Icon(Icons.settings),
-      SettingsPage(),
-    ),
+    Destinations('Settings', Icon(Icons.settings_outlined), Icon(Icons.settings), SettingsPage()),
   ];
-  final ScrollController _scrollController = ScrollController();
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     final bool tabletLayout = ResponsiveNav.isTablet(context);
     final double navIconSize = ResponsiveNav.iconSize(context);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
     return Scaffold(
       key: _scaffoldKey,
       drawer: NavigationDrawerTheme(
         data: NavigationDrawerTheme.of(context).copyWith(
-          labelTextStyle: WidgetStatePropertyAll(
-            ResponsiveNav.drawerLabelStyle(context),
-          ),
+          labelTextStyle: WidgetStatePropertyAll(ResponsiveNav.drawerLabelStyle(context)),
           tileHeight: ResponsiveNav.drawerTileHeight(context),
+          indicatorColor: colorScheme.secondaryContainer.withValues(alpha: 0.45),
+          indicatorShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
         ),
         child: NavigationDrawer(
           onDestinationSelected: (index) {
@@ -98,24 +69,17 @@ class _HomePageState extends State<HomePage> {
           },
           selectedIndex: _selectedIndex,
           tilePadding: _drawerTilePadding,
-          footer: _buildDrawerFooter(context),
           children: <Widget>[
-            SizedBox(height: tabletLayout ? 84 : 72),
+            SizedBox(height: tabletLayout ? 76 : 64),
             ..._pageDestinations.map((Destinations destination) {
               return NavigationDrawerDestination(
                 label: Text(destination.label),
                 icon: IconTheme(
-                  data: IconThemeData(
-                    color: colorScheme.onSurfaceVariant,
-                    size: navIconSize,
-                  ),
+                  data: IconThemeData(color: colorScheme.onSurfaceVariant, size: navIconSize),
                   child: destination.icon,
                 ),
                 selectedIcon: IconTheme(
-                  data: IconThemeData(
-                    color: colorScheme.onSecondaryContainer,
-                    size: navIconSize,
-                  ),
+                  data: IconThemeData(color: colorScheme.onSecondaryContainer, size: navIconSize),
                   child: destination.selectedIcon,
                 ),
               );
@@ -127,11 +91,20 @@ class _HomePageState extends State<HomePage> {
           ? AppBar(
               toolbarHeight: ResponsiveNav.toolbarHeight(context),
               title: Text(_pageDestinations[_selectedIndex].label),
-              iconTheme: IconThemeData(
-                color: Theme.of(context).colorScheme.onSurface,
-                size: navIconSize,
-              ),
               centerTitle: true,
+              iconTheme: IconThemeData(color: colorScheme.onSurface, size: navIconSize),
+              actions: <Widget>[
+                IconButton(
+                  tooltip: 'Toggle theme',
+                  onPressed: _toggleQuickTheme,
+                  icon: Icon(
+                    theme.brightness == Brightness.dark
+                        ? Icons.light_mode_rounded
+                        : Icons.dark_mode_rounded,
+                  ),
+                ),
+                const SizedBox(width: 6),
+              ],
             )
           : null,
       body: _pageDestinations[_selectedIndex].destination,
@@ -144,266 +117,14 @@ class _HomePageState extends State<HomePage> {
     });
   }
 
-  Widget _buildThemeToggleFooterButton(BuildContext context) {
+  Future<void> _toggleQuickTheme() async {
     final ThemeData theme = Theme.of(context);
-    final AdaptiveThemeMode themeMode = AdaptiveTheme.of(context).mode;
-    final bool isDark = themeMode.isSystem
-        ? theme.brightness == Brightness.dark
-        : themeMode.isDark;
+    final AdaptiveThemeMode mode = AdaptiveTheme.of(context).mode;
+    final bool isDark = mode.isSystem ? theme.brightness == Brightness.dark : mode.isDark;
+    final AdaptiveThemeMode nextMode = isDark ? AdaptiveThemeMode.light : AdaptiveThemeMode.dark;
 
-    return _buildDrawerFooterButton(
-      context: context,
-      icon: isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
-      label: isDark ? 'Light mode' : 'Dark mode',
-      onPressed: () async {
-        final AdaptiveThemeMode newMode = isDark
-            ? AdaptiveThemeMode.light
-            : AdaptiveThemeMode.dark;
-        await SettingsDB().put('themeMode', newMode.isDark ? 'dark' : 'light');
-        if (context.mounted) {
-          AdaptiveTheme.of(context).setThemeMode(newMode);
-        }
-      },
-    );
-  }
-
-  Widget _buildDrawerFooter(BuildContext context) {
-    return SafeArea(
-      top: false,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(0, 4, 0, 10),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            _buildThemeToggleFooterButton(context),
-            const SizedBox(height: 2),
-            _buildDrawerFooterButton(
-              context: context,
-              icon: Icons.info_outline,
-              label: 'About this app',
-              onPressed: () => _showAboutApp(context),
-            ),
-            const SizedBox(height: 2),
-            _buildDrawerFooterButton(
-              context: context,
-              icon: Icons.share_outlined,
-              label: 'Share this app',
-              onPressed: () => _shareApp(context),
-            ),
-            const SizedBox(height: 2),
-            _buildDrawerFooterButton(
-              context: context,
-              icon: Icons.feedback_outlined,
-              label: 'Feedback / Contact us',
-              onPressed: () => _openFeedbackContactPage(context),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDrawerFooterButton({
-    required BuildContext context,
-    required IconData icon,
-    required String label,
-    required VoidCallback onPressed,
-  }) {
-    final ThemeData theme = Theme.of(context);
-    final ColorScheme colorScheme = theme.colorScheme;
-    final TextStyle? labelStyle =
-        NavigationDrawerTheme.of(
-          context,
-        ).labelTextStyle?.resolve(<WidgetState>{}) ??
-        theme.textTheme.labelLarge?.copyWith(
-          color: colorScheme.onSurfaceVariant,
-        );
-
-    return Padding(
-      padding: _drawerTilePadding,
-      child: Material(
-        color: Colors.transparent,
-        borderRadius: BorderRadius.circular(AppRadii.large),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: onPressed,
-          child: SizedBox(
-            width: double.infinity,
-            height: ResponsiveNav.drawerFooterTileHeight(context),
-            child: Row(
-              children: <Widget>[
-                const SizedBox(width: _drawerTileLeadingGap),
-                SizedBox(
-                  width: ResponsiveNav.iconSize(context),
-                  child: Icon(
-                    icon,
-                    color: colorScheme.onSurfaceVariant,
-                    size: ResponsiveNav.iconSize(context),
-                  ),
-                ),
-                const SizedBox(width: _drawerTileIconLabelGap),
-                Expanded(
-                  child: Text(
-                    label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: labelStyle,
-                  ),
-                ),
-                const SizedBox(width: 16),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Future<void> _showAboutApp(BuildContext context) async {
-    final PackageInfo packageInfo = await PackageInfo.fromPlatform();
-    if (!context.mounted) return;
-
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    showAboutDialog(
-      context: context,
-      applicationName: 'eQuran',
-      applicationVersion: 'Version ${packageInfo.version}',
-      applicationIcon: Icon(
-        Icons.menu_book_rounded,
-        color: colorScheme.primary,
-        size: 40,
-      ),
-      children: const <Widget>[
-        SizedBox(height: 16),
-        Text(
-          'eQuran is a modern Quran companion designed for focused reading, listening, and daily reflection.',
-        ),
-        SizedBox(height: 12),
-        Text(
-          'Use it to continue where you left off, browse by Surah or Juz, stream recitation, play specific ayahs, and download audio for offline listening.',
-        ),
-        SizedBox(height: 12),
-        Text(
-          'Built with a clean Material 3 interface, eQuran keeps the experience simple, elegant, and reliable.',
-        ),
-      ],
-    );
-  }
-
-  Future<void> _shareApp(BuildContext context) async {
-    try {
-      await SharePlus.instance.share(
-        ShareParams(
-          title: 'eQuran',
-          subject: 'Download eQuran',
-          text: 'Download eQuran on F-Droid: $_appDownloadUrl',
-        ),
-      );
-    } catch (_) {
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Unable to open the share sheet.')),
-      );
-    }
-  }
-
-  void _openFeedbackContactPage(BuildContext context) {
-    final NavigatorState navigator = Navigator.of(context);
-    navigator.pop();
-    navigator.push(
-      MaterialPageRoute<void>(
-        builder: (context) => const FeedbackContactPage(),
-      ),
-    );
-  }
-}
-
-class FeedbackContactPage extends StatelessWidget {
-  const FeedbackContactPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-
-    return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: ResponsiveNav.toolbarHeight(context),
-        iconTheme: IconThemeData(size: ResponsiveNav.iconSize(context)),
-        title: const Text('Feedback / Contact us'),
-      ),
-      body: ListView(
-        physics: const BouncingScrollPhysics(),
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 18, 16, 8),
-            child: Text(
-              'Help improve eQuran',
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: theme.colorScheme.primary,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-            child: Text(
-              'We appreciate your suggestions and feedback; they help make eQuran better for everyone.',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ),
-          ListTile(
-            leading: const Icon(Icons.bug_report_outlined),
-            title: const Text('Report issues'),
-            subtitle: const Text('Open the GitHub issue tracker.'),
-            trailing: const Icon(Icons.open_in_new_rounded),
-            onTap: () => _launchUri(
-              context,
-              Uri.parse(_issueReportUrl),
-              errorMessage: 'Unable to open the issue tracker.',
-            ),
-          ),
-          ListTile(
-            leading: const Icon(Icons.alternate_email_rounded),
-            title: const Text('Contact'),
-            subtitle: const Text(_contactEmail),
-            trailing: const Icon(Icons.open_in_new_rounded),
-            onTap: () => _launchUri(
-              context,
-              Uri(
-                scheme: 'mailto',
-                path: _contactEmail,
-                queryParameters: <String, String>{'subject': 'eQuran feedback'},
-              ),
-              errorMessage: 'Unable to open your email app.',
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _launchUri(
-    BuildContext context,
-    Uri uri, {
-    required String errorMessage,
-  }) async {
-    final bool didLaunch;
-    try {
-      didLaunch = await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } catch (_) {
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(errorMessage)));
-      return;
-    }
-
-    if (didLaunch || !context.mounted) return;
-
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(errorMessage)));
+    await SettingsDB().put('themeMode', nextMode.isDark ? 'dark' : 'light');
+    if (!mounted) return;
+    AdaptiveTheme.of(context).setThemeMode(nextMode);
   }
 }

--- a/lib/home/main_page.dart
+++ b/lib/home/main_page.dart
@@ -1,3 +1,4 @@
+import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:equran/backend/library.dart';
 import 'package:equran/utils/app_radii.dart';
 import 'package:equran/utils/debouncer.dart';
@@ -153,16 +154,32 @@ class _MainPageState extends State<MainPage>
         ),
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 180),
-          child: _showSearch
-              ? const SizedBox(
-                  key: ValueKey<String>('search-button-hidden'),
-                  width: 0,
-                )
-              : IconButton(
-                  key: const ValueKey<String>('search-button'),
-                  onPressed: _openSearch,
-                  icon: const Icon(Icons.search_rounded),
+          child: Row(
+            key: ValueKey<bool>(_showSearch),
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (!_showSearch)
+                IconButton(
+                  tooltip: 'Toggle theme',
+                  onPressed: _toggleQuickTheme,
+                  icon: Icon(
+                    theme.brightness == Brightness.dark
+                        ? Icons.light_mode_rounded
+                        : Icons.dark_mode_rounded,
+                  ),
                 ),
+              _showSearch
+                  ? const SizedBox(
+                      key: ValueKey<String>('search-button-hidden'),
+                      width: 0,
+                    )
+                  : IconButton(
+                      key: const ValueKey<String>('search-button'),
+                      onPressed: _openSearch,
+                      icon: const Icon(Icons.search_rounded),
+                    ),
+            ],
+          ),
         ),
       ],
     );
@@ -371,10 +388,24 @@ class _MainPageState extends State<MainPage>
   }
 
   String get _searchHint => switch (_selectedSegment) {
-    1 => "Juz, surah, or number...",
+    1 => "Juz number or surah name...",
     2 => "Saved ayah, surah, note, or number...",
     _ => "Surah name or number...",
   };
+
+  Future<void> _toggleQuickTheme() async {
+    final ThemeData theme = Theme.of(context);
+    final AdaptiveThemeMode mode = AdaptiveTheme.of(context).mode;
+    final bool isDark = mode.isSystem
+        ? theme.brightness == Brightness.dark
+        : mode.isDark;
+    final AdaptiveThemeMode nextMode = isDark
+        ? AdaptiveThemeMode.light
+        : AdaptiveThemeMode.dark;
+    await SettingsDB().put('themeMode', nextMode.isDark ? 'dark' : 'light');
+    if (!mounted) return;
+    AdaptiveTheme.of(context).setThemeMode(nextMode);
+  }
 
   Widget? _buildLastReadCard() {
     if (SettingsDB().get("showLastRead", defaultValue: true) != true) {

--- a/lib/home/player.dart
+++ b/lib/home/player.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:ui' show DisplayFeature, DisplayFeatureType;
 
+import 'package:adaptive_theme/adaptive_theme.dart';
 import 'package:audioplayers/audioplayers.dart' as ap;
 import 'package:equran/backend/library.dart'
     show
@@ -11,6 +12,7 @@ import 'package:equran/backend/library.dart'
         DownloadNotifications,
         SettingsDB;
 import 'package:equran/utils/app_radii.dart';
+import 'package:equran/utils/app_slider_theme.dart';
 import 'package:equran/utils/responsive_nav.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -142,29 +144,6 @@ class PlayerPage extends StatefulWidget {
   State<PlayerPage> createState() => _PlayerPageState();
 }
 
-class _FullWidthSliderTrackShape extends RoundedRectSliderTrackShape {
-  const _FullWidthSliderTrackShape();
-
-  @override
-  Rect getPreferredRect({
-    required RenderBox parentBox,
-    Offset offset = Offset.zero,
-    required SliderThemeData sliderTheme,
-    bool isEnabled = false,
-    bool isDiscrete = false,
-  }) {
-    final double trackHeight = sliderTheme.trackHeight ?? 2;
-    final double trackTop =
-        offset.dy + (parentBox.size.height - trackHeight) / 2;
-    return Rect.fromLTWH(
-      offset.dx,
-      trackTop,
-      parentBox.size.width,
-      trackHeight,
-    );
-  }
-}
-
 class _PlayerPageState extends State<PlayerPage> {
   final ja.AudioPlayer _justAudio = ja.AudioPlayer();
   final ap.AudioPlayer _fallbackAudio = ap.AudioPlayer();
@@ -195,6 +174,7 @@ class _PlayerPageState extends State<PlayerPage> {
   bool _loopEnabled = false;
   bool _isCompletingTrack = false;
   bool _showProgressThumb = false;
+  double? _pendingSeekProgress;
 
   double _playbackRate = 1.0;
   Duration _position = Duration.zero;
@@ -215,6 +195,7 @@ class _PlayerPageState extends State<PlayerPage> {
 
     _bindAudioListeners();
     _refreshDownloadState();
+    unawaited(AndroidAudioDisplayMode.setLowFpsSuppressed(true));
   }
 
   void _bindAudioListeners() {
@@ -556,11 +537,8 @@ class _PlayerPageState extends State<PlayerPage> {
     required BuildContext context,
     required double progress,
   }) {
-    final SliderThemeData baseTheme = SliderTheme.of(context);
     return SliderTheme(
-      data: baseTheme.copyWith(
-        trackHeight: 8.0,
-        trackShape: const _FullWidthSliderTrackShape(),
+      data: AppSliderTheme.standard(context).copyWith(
         thumbShape: _showProgressThumb
             ? const RoundSliderThumbShape(enabledThumbRadius: 7)
             : SliderComponentShape.noThumb,
@@ -569,13 +547,23 @@ class _PlayerPageState extends State<PlayerPage> {
             : SliderComponentShape.noOverlay,
       ),
       child: Slider(
-        value: progress,
+        value: (_pendingSeekProgress ?? progress).clamp(0.0, 1.0),
         onChangeStart: (_) => _revealProgressThumb(),
         onChanged: (value) {
           _revealProgressThumb();
-          _seek(value);
+          _safeSetState(() {
+            _pendingSeekProgress = value;
+            final int pendingMs = (_duration.inMilliseconds * value).round();
+            _position = Duration(milliseconds: pendingMs);
+          });
         },
-        onChangeEnd: (_) => _hideProgressThumbSoon(),
+        onChangeEnd: (value) async {
+          _hideProgressThumbSoon();
+          await _seek(value);
+          _safeSetState(() {
+            _pendingSeekProgress = null;
+          });
+        },
       ),
     );
   }
@@ -871,6 +859,7 @@ class _PlayerPageState extends State<PlayerPage> {
   @override
   void dispose() {
     unawaited(AndroidAudioDisplayMode.setAudioPlaybackActive(false));
+    unawaited(AndroidAudioDisplayMode.setLowFpsSuppressed(false));
     _progressThumbTimer?.cancel();
     _positionSubscription?.cancel();
     _durationSubscription?.cancel();
@@ -887,6 +876,19 @@ class _PlayerPageState extends State<PlayerPage> {
 
   void _notifyAudioUserActivity() {
     AndroidAudioDisplayMode.notifyUserActivity();
+  }
+
+  Future<void> _toggleQuickTheme() async {
+    final ThemeData theme = Theme.of(context);
+    final AdaptiveThemeMode mode = AdaptiveTheme.of(context).mode;
+    final bool isDark =
+        mode.isSystem ? theme.brightness == Brightness.dark : mode.isDark;
+    final AdaptiveThemeMode nextMode = isDark
+        ? AdaptiveThemeMode.light
+        : AdaptiveThemeMode.dark;
+    await SettingsDB().put('themeMode', nextMode.isDark ? 'dark' : 'light');
+    if (!mounted) return;
+    AdaptiveTheme.of(context).setThemeMode(nextMode);
   }
 
   Widget _buildAudioInteractionBoundary({required Widget child}) {
@@ -1021,6 +1023,16 @@ class _PlayerPageState extends State<PlayerPage> {
                       Icons.menu_rounded,
                       size: ResponsiveNav.iconSize(context),
                     ),
+                  ),
+                ),
+                const Spacer(),
+                IconButton(
+                  tooltip: 'Toggle theme',
+                  onPressed: _toggleQuickTheme,
+                  icon: Icon(
+                    Theme.of(context).brightness == Brightness.dark
+                        ? Icons.light_mode_rounded
+                        : Icons.dark_mode_rounded,
                   ),
                 ),
               ],

--- a/lib/home/read.dart
+++ b/lib/home/read.dart
@@ -13,6 +13,7 @@ import 'package:equran/backend/library.dart'
         QuranAudioService,
         SettingsDB;
 import 'package:equran/utils/app_radii.dart';
+import 'package:equran/utils/app_slider_theme.dart';
 import 'package:equran/utils/responsive_nav.dart';
 import 'package:equran/utils/translation_display.dart';
 import 'package:equran/widgets/library.dart'
@@ -71,6 +72,7 @@ class _ReadPageState extends State<ReadPage> {
   bool _isVerseLoading = false;
   bool _isDownloadingSurahAyahs = false;
   bool _hasDownloadedSurahAyahs = false;
+  bool _hasDownloadedCurrentAyah = false;
   bool _continuousPlayback = false;
   bool _repeatIntervalEnabled = false;
   int _playbackRequestId = 0;
@@ -115,6 +117,7 @@ class _ReadPageState extends State<ReadPage> {
     _isDownloadingSurahAyahs = AudioDownloadService()
         .isSurahAyahsDownloadInProgress(_currentChapter);
     unawaited(_refreshSurahAyahDownloadState());
+    unawaited(_refreshCurrentAyahDownloadState());
     _pageFocusNode = FocusNode(debugLabel: 'Read Page Keyboard Focus');
     _getTotalVerses();
     _repeatStartVerse = _currentVerse;
@@ -132,6 +135,7 @@ class _ReadPageState extends State<ReadPage> {
       BookmarkDB().addReadingEntry(_currentChapter, _currentVerse);
     }
     unawaited(_setKeepScreenOn(false));
+    unawaited(AndroidAudioDisplayMode.setLowFpsSuppressed(false));
     unawaited(AndroidAudioDisplayMode.setAudioPlaybackActive(false));
     _playerPositionSubscription?.cancel();
     _playerDurationSubscription?.cancel();
@@ -504,9 +508,9 @@ class _ReadPageState extends State<ReadPage> {
                           ),
                   ),
                 IconButton(
-                  tooltip: 'Jump to verse',
+                  tooltip: 'Go to ayah',
                   onPressed: () => _showJumpToVerseDialog(context),
-                  icon: const Icon(Icons.format_list_numbered_rounded),
+                  icon: const Icon(Icons.my_location_rounded),
                 ),
                 const SizedBox(width: 6),
               ],
@@ -615,7 +619,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 Text(
-                  'Jump to verse',
+                  'Go to ayah',
                   style: theme.textTheme.titleLarge?.copyWith(
                     fontWeight: FontWeight.w700,
                   ),
@@ -705,10 +709,20 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
 
   Future<void> _updateKeepScreenOn() async {
     await _setKeepScreenOn(
-      !_viewMode &&
-          _playerVisible &&
+      _playerVisible &&
           (_continuousPlayback || _repeatIntervalEnabled),
     );
+  }
+
+  Future<void> _refreshCurrentAyahDownloadState() async {
+    final bool hasAyah = await AudioDownloadService().hasAyah(
+      _currentChapter,
+      _currentVerse,
+    );
+    if (!mounted) return;
+    setState(() {
+      _hasDownloadedCurrentAyah = hasAyah;
+    });
   }
 
   Future<void> _playVerse(
@@ -980,6 +994,32 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
           _isDownloadingSurahAyahs = false;
         });
       }
+    }
+  }
+
+  Future<void> _downloadCurrentAyah() async {
+    if (_isDownloadingSurahAyahs) return;
+    try {
+      setState(() {
+        _isDownloadingSurahAyahs = true;
+      });
+      await AudioDownloadService().downloadAyah(_currentChapter, _currentVerse);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Downloaded ayah $_currentChapter:$_currentVerse')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to download ayah audio.')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDownloadingSurahAyahs = false;
+        });
+      }
+      unawaited(_refreshCurrentAyahDownloadState());
     }
   }
 
@@ -1316,6 +1356,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
     setState(() {
       _currentVerse = value;
     });
+    unawaited(_refreshCurrentAyahDownloadState());
   }
 
   void _decrementVerse() {
@@ -1376,6 +1417,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
 
   void _updateDB() {
     BookmarkDB().addReadingEntry(_currentChapter, _currentVerse);
+    unawaited(_refreshCurrentAyahDownloadState());
   }
 
   void _updateVerseFromProgress({
@@ -1454,6 +1496,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
             onLongPressStart: (details) {
+              unawaited(AndroidAudioDisplayMode.setLowFpsSuppressed(true));
               setState(() {
                 _isScrubbingProgress = true;
                 _scrubStartVerse = _currentVerse;
@@ -1476,6 +1519,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
               );
             },
             onLongPressEnd: (_) {
+              unawaited(AndroidAudioDisplayMode.setLowFpsSuppressed(false));
               setState(() {
                 _isScrubbingProgress = false;
                 _scrubStartVerse = null;
@@ -1485,6 +1529,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
               });
             },
             onLongPressCancel: () {
+              unawaited(AndroidAudioDisplayMode.setLowFpsSuppressed(false));
               setState(() {
                 _isScrubbingProgress = false;
                 _scrubStartVerse = null;
@@ -1625,11 +1670,14 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                 children: <Widget>[
                   Padding(
                     padding: const EdgeInsets.only(right: 36),
-                    child: Slider(
-                      value: progress,
-                      onChanged: duration.inMilliseconds <= 0
-                          ? null
-                          : _seekBottomPlayer,
+                    child: SliderTheme(
+                      data: AppSliderTheme.standard(context),
+                      child: Slider(
+                        value: progress,
+                        onChanged: duration.inMilliseconds <= 0
+                            ? null
+                            : _seekBottomPlayer,
+                      ),
                     ),
                   ),
                   Row(
@@ -1655,7 +1703,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                     children: <Widget>[
                       _buildAutoPlaybackButton(colorScheme),
                       if (!_viewMode) ...<Widget>[
-                        const SizedBox(width: 8),
+                        const SizedBox(width: 14),
                         _buildPageViewAyahNavButton(
                           icon: Icons.skip_previous_rounded,
                           tooltip: 'Previous ayah',
@@ -1664,7 +1712,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                               : () => unawaited(_playAdjacentPageViewAyah(-1)),
                         ),
                       ],
-                      const SizedBox(width: 8),
+                      const SizedBox(width: 14),
                       FilledButton(
                         onPressed: _toggleBottomPlayer,
                         style: FilledButton.styleFrom(
@@ -1688,7 +1736,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                               ),
                       ),
                       if (!_viewMode) ...<Widget>[
-                        const SizedBox(width: 8),
+                        const SizedBox(width: 14),
                         _buildPageViewAyahNavButton(
                           icon: Icons.skip_next_rounded,
                           tooltip: 'Next ayah',
@@ -1698,7 +1746,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                               : () => unawaited(_playAdjacentPageViewAyah(1)),
                         ),
                       ],
-                      const SizedBox(width: 8),
+                      const SizedBox(width: 14),
                       _buildRepeatIntervalButton(colorScheme),
                     ],
                   ),
@@ -1787,6 +1835,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
                               _buildAutoPlaybackButton(colorScheme),
+                              const SizedBox(width: 10),
                               if (!_viewMode)
                                 _buildPageViewAyahNavButton(
                                   icon: Icons.skip_previous_rounded,
@@ -1798,6 +1847,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                                           _playAdjacentPageViewAyah(-1),
                                         ),
                                 ),
+                              const SizedBox(width: 10),
                               FilledButton(
                                 onPressed: _toggleBottomPlayer,
                                 style: FilledButton.styleFrom(
@@ -1832,6 +1882,7 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                                           _playAdjacentPageViewAyah(1),
                                         ),
                                 ),
+                              const SizedBox(width: 10),
                               _buildRepeatIntervalButton(colorScheme),
                             ],
                           ),
@@ -1851,11 +1902,14 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
                                 ),
                               ),
                               Expanded(
-                                child: Slider(
-                                  value: progress,
-                                  onChanged: duration.inMilliseconds <= 0
-                                      ? null
-                                      : _seekBottomPlayer,
+                                child: SliderTheme(
+                                  data: AppSliderTheme.standard(context),
+                                  child: Slider(
+                                    value: progress,
+                                    onChanged: duration.inMilliseconds <= 0
+                                        ? null
+                                        : _seekBottomPlayer,
+                                  ),
                                 ),
                               ),
                               SizedBox(
@@ -2095,10 +2149,24 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
     defaultValue: 18.0,
   ),
   onPlay: _togglePageViewPlayback,
-  onDownload: _downloadCurrentSurahAyahs,
+  onDownload: _downloadCurrentAyah,
+  onPrevious: _currentVerse > 1
+      ? () {
+          _setVerse(_currentVerse - 1);
+          _scrollUp();
+          _updateDB();
+        }
+      : null,
+  onNext: _currentVerse < _totalVerses
+      ? () {
+          _setVerse(_currentVerse + 1);
+          _scrollUp();
+          _updateDB();
+        }
+      : null,
   isPlaying: _isVersePlaying && _playingVerse == _currentVerse,
   isDownloading: _isDownloadingSurahAyahs,
-  isDownloaded: _hasDownloadedSurahAyahs,
+  isDownloaded: _hasDownloadedCurrentAyah,
 ),
                     ),
                     AnimatedContainer(
@@ -2527,6 +2595,11 @@ Future<void> _showJumpToVerseDialog(BuildContext context) async {
     final String key = _favouriteKey(_currentChapter, verse);
     if (isFavourite) {
       FavouritesDB().delete(key);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Removed from favourites.')),
+        );
+      }
       return;
     }
     FavouritesDB().put(key, '');

--- a/lib/home/settings.dart
+++ b/lib/home/settings.dart
@@ -15,6 +15,13 @@ import 'package:equran/widgets/library.dart'
 import 'package:flutter/material.dart';
 import 'package:quran/quran.dart' show Translation;
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const String _appDownloadUrl =
+    'https://f-droid.org/en/packages/com.app.equran/';
+const String _issueReportUrl = 'https://github.com/ya27hw/equran_app/issues';
+const String _contactEmail = 'equran@elbaesy.com';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -52,16 +59,31 @@ class _SettingsPageState extends State<SettingsPage> {
             subtitle: "App behavior and history",
             icon: Icons.tune_rounded,
             initiallyExpanded: true,
-            children: const <Widget>[
-              SettingsSwitch(
+            children: <Widget>[
+              const SettingsSwitch(
                 title: "Vibration",
                 subtitle: "Enable haptic feedback when navigating.",
                 settingsKey: "vibration",
               ),
-              SettingsSwitch(
+              const SettingsSwitch(
                 title: "Show reading history",
                 settingsKey: "showLastRead",
                 subtitle: "Shows you up to 7 last read Surahs.",
+              ),
+              ListTile(
+                leading: const Icon(Icons.info_outline_rounded),
+                title: const Text('About this app'),
+                onTap: () => _showAboutApp(context),
+              ),
+              ListTile(
+                leading: const Icon(Icons.share_outlined),
+                title: const Text('Share app'),
+                onTap: () => _shareApp(context),
+              ),
+              ListTile(
+                leading: const Icon(Icons.feedback_outlined),
+                title: const Text('Feedback / Contact'),
+                onTap: () => _openFeedbackContactPage(context),
               ),
             ],
           ),
@@ -666,6 +688,112 @@ class _SettingsPageState extends State<SettingsPage> {
   String _selectedReciterName() {
     final dynamic savedReciter = SettingsDB().get("reciter", defaultValue: "1");
     return AppReciter.fromCode(savedReciter?.toString()).englishName;
+  }
+
+  Future<void> _showAboutApp(BuildContext context) async {
+    final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    if (!context.mounted) return;
+
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    showAboutDialog(
+      context: context,
+      applicationName: 'eQuran',
+      applicationVersion: 'Version ${packageInfo.version}',
+      applicationIcon: Icon(
+        Icons.menu_book_rounded,
+        color: colorScheme.primary,
+        size: 40,
+      ),
+      children: const <Widget>[
+        SizedBox(height: 16),
+        Text(
+          'eQuran is a modern Quran companion designed for focused reading, listening, and daily reflection.',
+        ),
+      ],
+    );
+  }
+
+  Future<void> _shareApp(BuildContext context) async {
+    try {
+      await SharePlus.instance.share(
+        ShareParams(
+          title: 'eQuran',
+          subject: 'Download eQuran',
+          text: 'Download eQuran on F-Droid: $_appDownloadUrl',
+        ),
+      );
+    } catch (_) {
+      if (!context.mounted) return;
+      _showMessage(context, 'Unable to open the share sheet.');
+    }
+  }
+
+  void _openFeedbackContactPage(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) => const _FeedbackContactPage(),
+      ),
+    );
+  }
+}
+
+class _FeedbackContactPage extends StatelessWidget {
+  const _FeedbackContactPage();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Feedback / Contact')),
+      body: ListView(
+        physics: const BouncingScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: <Widget>[
+          ListTile(
+            leading: const Icon(Icons.bug_report_outlined),
+            title: const Text('Report issues'),
+            subtitle: const Text('Open the GitHub issue tracker.'),
+            trailing: const Icon(Icons.open_in_new_rounded),
+            onTap: () async {
+              final Uri uri = Uri.parse(_issueReportUrl);
+              if (!await launchUrl(uri, mode: LaunchMode.externalApplication) &&
+                  context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Unable to open issue tracker.')),
+                );
+              }
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.email_outlined),
+            title: const Text('Email support'),
+            subtitle: Text(_contactEmail),
+            trailing: const Icon(Icons.open_in_new_rounded),
+            onTap: () async {
+              final Uri uri = Uri(
+                scheme: 'mailto',
+                path: _contactEmail,
+                queryParameters: <String, String>{'subject': 'eQuran feedback'},
+              );
+              if (!await launchUrl(uri) && context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Unable to open email client.')),
+                );
+              }
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+            child: Text(
+              'We appreciate your feedback and suggestions.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/utils/app_slider_theme.dart
+++ b/lib/utils/app_slider_theme.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class AppSliderTheme {
+  const AppSliderTheme._();
+
+  static SliderThemeData standard(BuildContext context) {
+    final SliderThemeData base = SliderTheme.of(context);
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    return base.copyWith(
+      trackHeight: 8,
+      inactiveTrackColor: scheme.surfaceContainerHighest,
+      activeTrackColor: scheme.primary,
+      thumbColor: scheme.primary,
+      overlayColor: scheme.primary.withValues(alpha: 0.14),
+      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
+      overlayShape: const RoundSliderOverlayShape(overlayRadius: 16),
+    );
+  }
+}

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 class AppTheme {
   const AppTheme._();
@@ -29,9 +30,12 @@ class AppTheme {
       ),
     );
 
+    final TextTheme textTheme = GoogleFonts.interTextTheme();
     return ThemeData(
       useMaterial3: true,
       colorScheme: colorScheme,
+      textTheme: textTheme,
+      primaryTextTheme: textTheme,
       scaffoldBackgroundColor: const Color(0xFFF4F1EE),
       canvasColor: const Color(0xFFF4F1EE),
       cardTheme: CardThemeData(
@@ -48,12 +52,17 @@ class AppTheme {
   }
 
   static ThemeData buildDarkTheme(Color seedColor) {
+    final TextTheme textTheme = GoogleFonts.interTextTheme(
+      ThemeData(brightness: Brightness.dark).textTheme,
+    );
     return ThemeData(
       useMaterial3: true,
       colorScheme: ColorScheme.fromSeed(
         seedColor: seedColor,
         brightness: Brightness.dark,
       ),
+      textTheme: textTheme,
+      primaryTextTheme: textTheme,
     );
   }
 }

--- a/lib/widgets/app_selection_dialog.dart
+++ b/lib/widgets/app_selection_dialog.dart
@@ -79,7 +79,7 @@ class AppSelectionDialog<T> extends StatelessWidget {
               child: ClipRect(
                 child: ListView.builder(
                   shrinkWrap: true,
-                  physics: const ClampingScrollPhysics(),
+                  physics: const BouncingScrollPhysics(),
                   padding: const EdgeInsets.symmetric(vertical: 8),
                   itemCount: options.length,
                   itemBuilder: (context, index) {

--- a/lib/widgets/font_slider.dart
+++ b/lib/widgets/font_slider.dart
@@ -1,4 +1,5 @@
 import 'package:equran/backend/library.dart' show SettingsDB;
+import 'package:equran/utils/app_slider_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:quran/quran.dart' as quran;
 
@@ -14,69 +15,42 @@ class FontSlider extends StatefulWidget {
 class _FontSliderState extends State<FontSlider> {
   @override
   Widget build(BuildContext context) {
-    double fontSize = SettingsDB().get("fontSize", defaultValue: 38.0);
+    double fontSize = SettingsDB().get('fontSize', defaultValue: 38.0);
     double fontSizeTranslation = SettingsDB().get(
-      "fontSizeTranslation",
+      'fontSizeTranslation',
       defaultValue: 15.0,
     );
+
     return Column(
-      children: [
-        ListTile(
-          title: const Center(child: Text("Font Size")),
-          subtitle: Row(
-            children: <Widget>[
-              Expanded(
-                child: Slider(
-                  value: fontSize,
-                  min: 25.0,
-                  max: 65.0,
-                  label: fontSize.round().toString(),
-                  onChanged: (double value) {
-                    setState(() {
-                      fontSize = value;
-                      SettingsDB().put("fontSize", value);
-                    });
-                  },
-                ),
-              ),
-              SizedBox(
-                width: 42,
-                child: Text(
-                  fontSize.round().toString(),
-                  textAlign: TextAlign.end,
-                ),
-              ),
-            ],
-          ),
+      children: <Widget>[
+        _buildSliderRow(
+          context: context,
+          title: 'Arabic text size',
+          subtitle: 'Controls Quran Arabic script size in reading screens.',
+          value: fontSize,
+          min: 25,
+          max: 65,
+          onChanged: (value) {
+            setState(() {
+              fontSize = value;
+              SettingsDB().put('fontSize', value);
+            });
+          },
         ),
         if (widget.showTranslationControls)
-          ListTile(
-            title: const Center(child: Text("Translation Font Size")),
-            subtitle: Row(
-              children: <Widget>[
-                Expanded(
-                  child: Slider(
-                    value: fontSizeTranslation,
-                    min: 10.0,
-                    max: 30.0,
-                    label: fontSizeTranslation.round().toString(),
-                    onChanged: (double value) {
-                      setState(() {
-                        fontSizeTranslation = value;
-                        SettingsDB().put("fontSizeTranslation", value);
-                      });
-                    },
-                  ),
-                ),
-                SizedBox(
-                  width: 42,
-                  child: Text(
-                    fontSizeTranslation.round().toString(),
-                    textAlign: TextAlign.end,
-                  ),
-                ),
-              ],
-            ),
+          _buildSliderRow(
+            context: context,
+            title: 'Translation text size',
+            subtitle: 'Controls translated verse text size in card view.',
+            value: fontSizeTranslation,
+            min: 10,
+            max: 30,
+            onChanged: (value) {
+              setState(() {
+                fontSizeTranslation = value;
+                SettingsDB().put('fontSizeTranslation', value);
+              });
+            },
           ),
         _FontPreview(
           fontSize: fontSize,
@@ -86,6 +60,62 @@ class _FontSliderState extends State<FontSlider> {
       ],
     );
   }
+
+  Widget _buildSliderRow({
+    required BuildContext context,
+    required String title,
+    required String subtitle,
+    required double value,
+    required double min,
+    required double max,
+    required ValueChanged<double> onChanged,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 2, 16, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(title, style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 2),
+          Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
+          const SizedBox(height: 4),
+          Row(
+            children: <Widget>[
+              Text('A−', style: Theme.of(context).textTheme.labelMedium),
+              Expanded(
+                child: SliderTheme(
+                  data: AppSliderTheme.standard(context),
+                  child: Slider(
+                    value: value,
+                    min: min,
+                    max: max,
+                    label: _formatToThreeSignificantFigures(value),
+                    onChanged: onChanged,
+                  ),
+                ),
+              ),
+              Text('A+', style: Theme.of(context).textTheme.labelMedium),
+              const SizedBox(width: 8),
+              SizedBox(
+                width: 56,
+                child: Text(
+                  _formatToThreeSignificantFigures(value),
+                  textAlign: TextAlign.end,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatToThreeSignificantFigures(double value) {
+  final String compact = value.toStringAsPrecision(3);
+  return compact.contains('.')
+      ? compact.replaceFirst(RegExp(r'\.?0+$'), '')
+      : compact;
 }
 
 class _FontPreview extends StatelessWidget {
@@ -103,6 +133,10 @@ class _FontPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
+
+    final int translationIndex = SettingsDB().get('translation', defaultValue: 0);
+    final quran.Translation selectedTranslation = quran.Translation.values[
+        translationIndex.clamp(0, quran.Translation.values.length - 1)];
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 18),
@@ -122,7 +156,7 @@ class _FontPreview extends StatelessWidget {
           if (showTranslation) ...<Widget>[
             const SizedBox(height: 12),
             Text(
-              quran.getVerseTranslation(1, 1),
+              quran.getVerseTranslation(1, 1, translation: selectedTranslation),
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: colorScheme.onSurfaceVariant,

--- a/lib/widgets/juz_card_list.dart
+++ b/lib/widgets/juz_card_list.dart
@@ -225,6 +225,11 @@ class _JuzEntry {
   final int endVerse;
 
   bool matches(String query, int juzNumber) {
-    return juzNumber.toString() == query;
+    final String normalized = query.trim().toLowerCase();
+    if (normalized.isEmpty) return true;
+    return juzNumber.toString() == normalized ||
+        juzNumber.toString().startsWith(normalized) ||
+        transliteration.toLowerCase().contains(normalized) ||
+        name.contains(query);
   }
 }

--- a/lib/widgets/playback_rate.dart
+++ b/lib/widgets/playback_rate.dart
@@ -1,4 +1,5 @@
 import 'package:equran/backend/library.dart';
+import 'package:equran/utils/app_slider_theme.dart';
 import 'package:flutter/material.dart';
 
 class PlayBackSlider extends StatefulWidget {
@@ -14,18 +15,21 @@ class _PlayBackSliderState extends State<PlayBackSlider> {
     double rate = SettingsDB().get("playbackRate", defaultValue: 1.0);
     return ListTile(
       title: const Text("Playback Rate"),
-      subtitle: Slider(
-        min: 0.5,
-        max: 2,
-        divisions: 6,
-        label: rate.toString(),
-        value: rate,
-        onChanged: (double value) {
-          setState(() {
-            rate = value;
-            SettingsDB().put("playbackRate", value);
-          });
-        },
+      subtitle: SliderTheme(
+        data: AppSliderTheme.standard(context),
+        child: Slider(
+          min: 0.5,
+          max: 2,
+          divisions: 6,
+          label: '${rate.toStringAsFixed(2)}x',
+          value: rate,
+          onChanged: (double value) {
+            setState(() {
+              rate = value;
+              SettingsDB().put("playbackRate", value);
+            });
+          },
+        ),
       ),
     );
   }

--- a/lib/widgets/read_quran_card.dart
+++ b/lib/widgets/read_quran_card.dart
@@ -21,6 +21,8 @@ class ReadQuranCard extends StatelessWidget {
   final bool showActions;
 
   final VoidCallback? onPlay;
+  final VoidCallback? onPrevious;
+  final VoidCallback? onNext;
   final VoidCallback? onDownload;
   final bool isPlaying;
   final bool isDownloading;
@@ -39,6 +41,8 @@ class ReadQuranCard extends StatelessWidget {
     required this.verse,
     this.showActions = true,
     this.onPlay,
+    this.onPrevious,
+    this.onNext,
     this.onDownload,
     this.isPlaying = false,
     this.isDownloading = false,
@@ -185,6 +189,16 @@ class ReadQuranCard extends StatelessWidget {
             children: <Widget>[
               _buildActionButton(
                 context: context,
+                tooltip: 'Previous ayah',
+                onPressed: onPrevious,
+                child: Icon(
+                  Icons.skip_previous_rounded,
+                  size: 24,
+                  color: colorScheme.onSurface.withAlpha(185),
+                ),
+              ),
+              _buildActionButton(
+                context: context,
                 tooltip: isPlaying ? 'Pause' : 'Play',
                 onPressed: onPlay,
                 isPrimary: true,
@@ -199,10 +213,10 @@ class ReadQuranCard extends StatelessWidget {
               _buildActionButton(
                 context: context,
                 tooltip: isDownloaded
-                    ? 'All ayahs downloaded'
+                    ? 'Current ayah downloaded'
                     : isDownloading
                     ? 'Downloading'
-                    : 'Download all ayahs',
+                    : 'Download current ayah',
                 onPressed: isDownloading ? null : onDownload,
                 child: isDownloading
                     ? SizedBox(
@@ -220,6 +234,16 @@ class ReadQuranCard extends StatelessWidget {
                         size: 22,
                         color: colorScheme.onSurface.withAlpha(185),
                       ),
+              ),
+              _buildActionButton(
+                context: context,
+                tooltip: 'Next ayah',
+                onPressed: onNext,
+                child: Icon(
+                  Icons.skip_next_rounded,
+                  size: 24,
+                  color: colorScheme.onSurface.withAlpha(185),
+                ),
               ),
               _buildActionButton(
                 context: context,


### PR DESCRIPTION
### Motivation
- Improve interaction reliability and touch comfort in audio playback controls and progress seeking across the app.
- Make sliders and labels consistent with the Player page, and present clearer, friendlier settings UI (no raw decimals).
- Keep the reading page responsive during continuous playback (prevent device sleep) and avoid low-FPS mode interfering with feedback-heavy flows.
- Reduce sidebar clutter and move utility actions into Settings while adding a subtle quick theme control in headers.

### Description
- Implemented a reusable slider theme (`lib/utils/app_slider_theme.dart`) and applied it to player, font, and playback-rate sliders to unify visuals and make reversion easy; major uses in `lib/home/player.dart`, `lib/widgets/font_slider.dart`, and `lib/widgets/playback_rate.dart`.
- Reworked player progress seeking to a robust preview-and-seek-on-release pattern to improve hit-testing and reduce missed taps by tracking a `_pendingSeekProgress` value and updating position on `onChangeEnd` (`lib/home/player.dart`).
- Increased horizontal spacing and adjusted group spacing in the read page audio/player bars, and added previous/next media buttons to Card view with disabled-state wiring at first/last ayah (`lib/home/read.dart`, `lib/widgets/read_quran_card.dart`).
- Fixed Card view download action so the download button targets only the currently focused ayah and added `_downloadCurrentAyah` plus download-state refresh (`lib/home/read.dart`, `lib/widgets/read_quran_card.dart`).
- Improved font-size slider UX: clearer labels, A−/A+ axis wording, numeric labels formatted to three significant figures, and made translation preview reflect the currently selected translation immediately (`lib/widgets/font_slider.dart`, `lib/home/settings.dart`).
- Prevented device sleep while continuous/repeat playback is active on the reading page and ensured `setKeepScreenOn(false)` and Android low-FPS suppression are restored on stop/dispose (`lib/home/read.dart`, platform channel interaction retained). 
- Added low-FPS suppression API to `AndroidAudioDisplayMode` and used it to disable low-FPS mode during feedback-heavy interactions and when the Surah player page is active (`lib/backend/android_audio_display_mode.dart`, `lib/home/player.dart`, `lib/home/read.dart`).
- Updated UI polish and behavior: renamed drawer main item to “Home”, focused main drawer entries on Home/Player/Downloads/Settings, moved About/Share/Feedback into Settings, removed heavy drawer theme toggle and added tasteful quick theme toggles in header/app-bar areas (`lib/home/home.dart`, `lib/home/main_page.dart`, `lib/home/player.dart`, `lib/home/settings.dart`).
- Minor polish and safety changes: bouncing scroll physics for selection dialog lists, Juz search matching improvements and hint update, snackbar on removing favorites, and app-wide UI font switched to `Inter` via the theme while preserving the Arabic ayah font (`lib/widgets/app_selection_dialog.dart`, `lib/widgets/juz_card_list.dart`, `lib/home/read.dart`, `lib/utils/app_theme.dart`).

### Testing
- Ran `git diff --check` to validate changes and it returned no whitespace errors (passed). 
- Attempted `dart format` for modified files but the environment lacks the Dart SDK so formatting could not be executed here (not run). 
- Attempted to query `flutter --version` but `flutter` is not installed in this environment so runtime/visual verification and integration tests could not be executed (not run). 
- Manual code inspections and small runtime-guarded flows were added (platform checks and `mounted` guards) to avoid regressions; recommend running `dart format` and a local device/emulator smoke test focusing on: player seeking/preview, read-page keep-screen-on behavior, card-view prev/next + per-ayah download, settings font preview live update, and navigation drawer behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e852205a24832ba52b4bc59d9244ca)